### PR TITLE
Extend tools

### DIFF
--- a/sinta/ScriptRunner.cpp
+++ b/sinta/ScriptRunner.cpp
@@ -49,13 +49,16 @@ ScriptRunner::~ScriptRunner() {
 void ScriptRunner::runScript(const QString& path) {
     optional<QString> maybeScript = loadScript(path);
     if (!maybeScript.has_value()) {
-        return;
+        qFatal("Loading script failed");
     }
     QJSValue result = mEngine->evaluate(maybeScript.value(), path);
     if (result.isError()) {
-        qWarning() << "Error line" << result.property("lineNumber").toInt() << ":"
-                   << result.toString();
-    } else if (!result.isUndefined()) {
+        int line = result.property("lineNumber").toInt();
+        QString message = result.toString();
+        qFatal("Error line %d: %s", line, qPrintable(message));
+    }
+
+    if (!result.isUndefined()) {
         qInfo() << "result=" << result.toString();
     }
 }

--- a/sinta/ScriptRunner.cpp
+++ b/sinta/ScriptRunner.cpp
@@ -40,7 +40,7 @@ optional<QString> loadScript(const QString& path) {
 
 ScriptRunner::ScriptRunner() : mEngine(std::make_unique<QJSEngine>()) {
     mEngine->installExtensions(QJSEngine::AllExtensions);
-    mEngine->globalObject().setProperty("tools", mEngine->newQObject(new Tools));
+    mEngine->globalObject().setProperty("tools", mEngine->newQObject(new Tools(mEngine.get())));
 }
 
 ScriptRunner::~ScriptRunner() {

--- a/sinta/Tools.cpp
+++ b/sinta/Tools.cpp
@@ -26,6 +26,17 @@
 #include <QTimer>
 #include <QWidget>
 
+// Call a JS function, abort if it failed
+static QJSValue checkJsCall(const QJSValue& function, const QJSValueList& args = {}) {
+    auto result = QJSValue(function).call(args);
+    if (result.isError()) {
+        int line = result.property("lineNumber").toInt();
+        QString message = result.toString();
+        qFatal("Error line %d: %s", line, qPrintable(message));
+    }
+    return result;
+}
+
 Tools::Tools(QJSEngine* engine, QObject* parent) : QObject(parent), mEngine(engine) {
 }
 
@@ -48,12 +59,9 @@ void Tools::processEvents() {
     QApplication::processEvents();
 }
 
-void Tools::setTimeout(const QJSValue& value_, int ms) {
-    QJSValue value = value_;
-    QTimer::singleShot(ms, nullptr, [value] {
-        // Don't know why, but g++ thinks `value` is const, so create a local
-        // copy to be able to call `QJSValue::call()`
-        QJSValue(value).call();
+void Tools::setTimeout(const QJSValue& function, int ms) {
+    QTimer::singleShot(ms, nullptr, [function] {
+        checkJsCall(function);
     });
 }
 
@@ -86,14 +94,14 @@ void Tools::waitForActiveWindowAsyncImpl(const QJSValue& function,
                                          const QTime& deadLine) {
     if (QTime::currentTime() > deadLine) {
         qWarning() << QString("Call to waitForActiveWindowAsync() hit timeout.");
-        QJSValue(function).call({QJSValue()});
+        checkJsCall(function, {QJSValue()});
         return;
     }
     auto* window = activeWindow();
     if (window && window != excludedWindow) {
         // We found it
         auto windowValue = mEngine->newQObject(window);
-        QJSValue(function).call({windowValue});
+        checkJsCall(function, {windowValue});
     } else {
         // Try again
         QTimer::singleShot(0, this, [this, function, excludedWindow, deadLine] {

--- a/sinta/Tools.cpp
+++ b/sinta/Tools.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QPixmap>
 #include <QQmlEngine>
+#include <QTime>
 #include <QTimer>
 #include <QWidget>
 
@@ -54,4 +55,21 @@ void Tools::setTimeout(const QJSValue& value_, int ms) {
         // copy to be able to call `QJSValue::call()`
         QJSValue(value).call();
     });
+}
+
+QWidget* Tools::waitForActiveWindow(QWidget* excludedWindow, int maxTimeout) {
+    QTime chrono;
+    chrono.start();
+    while (chrono.elapsed() < maxTimeout) {
+        auto* window = activeWindow();
+        if (window && window != excludedWindow) {
+            return window;
+        }
+        processEvents();
+    }
+    qWarning() << QString("Call to waitForActiveWindow(%1, %2) hit timeout (waited for %3ms).")
+                      .arg(reinterpret_cast<intptr_t>(excludedWindow))
+                      .arg(maxTimeout)
+                      .arg(chrono.elapsed());
+    return nullptr;
 }

--- a/sinta/Tools.h
+++ b/sinta/Tools.h
@@ -21,7 +21,9 @@
 
 #include <QObject>
 
+class QJSEngine;
 class QJSValue;
+class QTime;
 
 /**
  * An instance of this object is exposed as `tools` in the JavaScript world
@@ -29,7 +31,7 @@ class QJSValue;
 class Tools : public QObject {
     Q_OBJECT
 public:
-    explicit Tools(QObject* parent = nullptr);
+    explicit Tools(QJSEngine* engine, QObject* parent = nullptr);
 
     /**
      * Takes a screenshot of widget, save it under path
@@ -68,6 +70,24 @@ public:
      */
     Q_INVOKABLE QWidget* waitForActiveWindow(QWidget* excludedWindow = nullptr,
                                              int maxTimeout = 3000);
+
+    /**
+     * Async version of waitForActiveWindow.
+     * Regularly calls itself back until it finds an active window or the timeout is hit.
+     *
+     * If it finds an active window, calls function with the window as the first argument.
+     * If it hits the timeout, calls function with a null object as the first argument.
+     */
+    Q_INVOKABLE void waitForActiveWindowAsync(const QJSValue& function,
+                                              QWidget* excludedWindow = nullptr,
+                                              int maxTimeout = 3000);
+
+private:
+    QJSEngine* const mEngine;
+
+    void waitForActiveWindowAsyncImpl(const QJSValue& function,
+                                      QWidget* excludedWindow,
+                                      const QTime& deadLine);
 };
 
 #endif // TOOLS_H

--- a/sinta/Tools.h
+++ b/sinta/Tools.h
@@ -58,6 +58,16 @@ public:
      * browsers.
      */
     Q_INVOKABLE void setTimeout(const QJSValue& function, int ms);
+
+    /**
+     * Process events until a window is active.
+     * If excludedWindow is not null, ignore the active window if it is excludedWindow.
+     * This is useful to find child windows: you can just ignore the parent.
+     *
+     * Returns the window if found or nullptr if we waited for too long
+     */
+    Q_INVOKABLE QWidget* waitForActiveWindow(QWidget* excludedWindow = nullptr,
+                                             int maxTimeout = 3000);
 };
 
 #endif // TOOLS_H

--- a/sinta/Tools.h
+++ b/sinta/Tools.h
@@ -21,9 +21,11 @@
 
 #include <QObject>
 
+#include <memory>
+
+class QDeadlineTimer;
 class QJSEngine;
 class QJSValue;
-class QTime;
 
 /**
  * An instance of this object is exposed as `tools` in the JavaScript world
@@ -87,7 +89,7 @@ private:
 
     void waitForActiveWindowAsyncImpl(const QJSValue& function,
                                       QWidget* excludedWindow,
-                                      const QTime& deadLine);
+                                      const QDeadlineTimer& timer);
 };
 
 #endif // TOOLS_H

--- a/testapp/test.js
+++ b/testapp/test.js
@@ -1,25 +1,5 @@
-function waitFor(fcn) {
-    while (true) {
-        var result = fcn();
-        if (result) {
-            return result;
-        }
-        tools.processEvents();
-    }
-}
-
-function waitForActiveWindow(excluded) {
-    return waitFor(function() {
-        var window = tools.activeWindow();
-        if (window === null || window === excluded) {
-            return null;
-        }
-        return window;
-    });
-}
-
 // Wait for the main window to be visible
-var mainWindow = waitForActiveWindow();
+var mainWindow = tools.waitForActiveWindow();
 console.log("mainWindow=" + mainWindow);
 
 // Take a screenshot of it
@@ -36,7 +16,7 @@ for (idx = 0; idx < 10; ++idx) {
     console.log(fontName);
 
     popupButton.click();
-    var popup = waitForActiveWindow(mainWindow);
+    var popup = tools.waitForActiveWindow(mainWindow);
     tools.screenshot(popup, fontName + ".png");
     popup.close();
 }

--- a/testapp/test.js
+++ b/testapp/test.js
@@ -1,25 +1,28 @@
-// Wait for the main window to be visible
-var mainWindow = tools.waitForActiveWindow();
-console.log("mainWindow=" + mainWindow);
+function runScript(mainWindow) {
+    // Wait for the main window to be visible
+    console.log("mainWindow=" + mainWindow);
 
-// Take a screenshot of it
-tools.screenshot(mainWindow, "mainwindow.png");
+    // Take a screenshot of it
+    tools.screenshot(mainWindow, "mainwindow.png");
 
-// Find the UI elements we need. The names are the QObject name.
-var popupButton = tools.findChild(mainWindow, "openPopupButton");
-var fontComboBox = tools.findChild(mainWindow, "fontComboBox");
+    // Find the UI elements we need. The names are the QObject name.
+    var popupButton = tools.findChild(mainWindow, "openPopupButton");
+    var fontComboBox = tools.findChild(mainWindow, "fontComboBox");
 
-// Loop on fonts, open the popup and take a screenshot of it
-for (idx = 0; idx < 10; ++idx) {
-    fontComboBox.setCurrentIndex(idx);
-    var fontName = fontComboBox.currentText;
-    console.log(fontName);
+    // Loop on fonts, open the popup and take a screenshot of it
+    for (idx = 0; idx < 10; ++idx) {
+        fontComboBox.setCurrentIndex(idx);
+        var fontName = fontComboBox.currentText;
+        console.log(fontName);
 
-    popupButton.click();
-    var popup = tools.waitForActiveWindow(mainWindow);
-    tools.screenshot(popup, fontName + ".png");
-    popup.close();
+        popupButton.click();
+        var popup = tools.waitForActiveWindow(mainWindow);
+        tools.screenshot(popup, fontName + ".png");
+        popup.close();
+    }
+
+    // Close the app
+    mainWindow.close();
 }
 
-// Close the app
-mainWindow.close();
+tools.waitForActiveWindowAsync(runScript);


### PR DESCRIPTION
This PR adds some handy method to the `tools` object:
- waitForActiveWindow()
- waitForActiveWindowAsync()

It also makes the app abort in case of errors in script instead of silently ignoring them.

Sponsored by [Genymobile][] for #Hacktoberfest!

[Genymobile]: https://genymobile.com